### PR TITLE
move PowerDNS dashboard from root of site for using root by PowerDNS-Admin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
     hostname: ${APP_TAG}
     labels:
       - traefik.http.services.${APP_TAG}.loadbalancer.server.port=8081
+      - traefik.http.middlewares.${APP_TAG}-prefix.stripprefix.prefixes=/pdns
+      - traefik.http.routers.${APP_TAG.rule=Host(`${APP_SITE}`) && PathPrefix(`/pdns/`)
+      - traefik.http.routers.${APP_TAG}.middlewares=${APP_TAG}-prefix@docker
     environment:
       - PDNS_API_KEY=${API_KEY}
       - PDNS_API=yes


### PR DESCRIPTION
Для использования даша PowerDNS, не принципиально его нахождение в корне (например dashboard traefik)
А если сам powerdns делать по url /pdns/ (или /dashboard/), то на тот же APP_SITE fqdn можно повесить powerdnsadmin.
Работать с API удобнее через PoweDNS-Admin:
- ключи генерятся под каждый сервис
- ключи можно ограничивать доменами/аккаунтами